### PR TITLE
Fix state ordering bug

### DIFF
--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -94,7 +94,6 @@ class MonteCarlo(predictor.Predictor):
         future_load.fcn = future_loading_eqn
 
         # Optimization to reduce lookup
-        output = self.model.output
         simulate_to_threshold = self.model.simulate_to_threshold
         threshold_met = self.model.threshold_met
         prediction_fcn.params = params

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -59,7 +59,7 @@ class ParticleFilter(state_estimator.StateEstimator):
             x = array(list(x0.values()))
             sd = array([self.parameters['x0_uncertainty']] * len(x0))
             samples = array([random.normal(x, sd) for i in range(self.parameters['num_particles'])])
-            self.particles = array([{key: value for (key, value) in zip(model.states, x)} for x in samples])
+            self.particles = array([{key: value for (key, value) in zip(x0.keys(), x)} for x in samples])
         else:
             raise ProgAlgTypeError
     

--- a/src/prog_algs/state_estimators/unscented_kalman_filter.py
+++ b/src/prog_algs/state_estimators/unscented_kalman_filter.py
@@ -58,10 +58,12 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         if 'Q' not in self.parameters:
             self.parameters['Q'] = diag([1.0e-1 for i in model.states])
         if 'R' not in self.parameters:
+            # Size of what's being measured (not output) 
+            # This is determined by running the measure function on the first state
             self.parameters['R'] = diag([1.0e-1 for i in range(len(measure(x0.values())))])
 
         def state_transition(x, dt):
-            x = {key: value for (key, value) in zip(model.states, x)}
+            x = {key: value for (key, value) in zip(x0.keys(), x)}
             x = model.next_state(x, self._input, dt)
             return array(list(x.values()))
 


### PR DESCRIPTION
Prog_algs uses a dictionary to store the state, but filterpy uses a numpy array. Unscented Kalman Filter and Particle Filter uses a numpy array internally to store state so it can be passed easily into filterpy. It then gets converted back to a dict at each step. This translation relies on strict ordering of dicts present in Python 3.6+. 

Here there was a bug where I was building the dict using not the order of keys from the dict but from the state tag list (model.state). It's really a miracle that this didn't cause an issue earlier, but not it's causing compatibility updates with the latest model changes.

I also removed an unnecessary line in the MC