### PR TITLE
Add ToE Prediction Profile

### DIFF
--- a/src/prog_algs/predictors/__init__.py
+++ b/src/prog_algs/predictors/__init__.py
@@ -3,5 +3,6 @@
 from .monte_carlo import MonteCarlo
 from .predictor import Predictor
 from .prediction import Prediction
+from .toe_prediction_profile import ToEPredictionProfile
 from .unscented_transform import UnscentedTransformPredictor
-__all__ = ['predictor', 'monte_carlo', 'unscented_transform', 'MonteCarlo', 'Predictor', 'Prediction', 'UnscentedTransformPredictor']
+__all__ = ['predictor', 'monte_carlo', 'unscented_transform', 'MonteCarlo', 'Predictor', 'Prediction', 'ToEPredictionProfile', 'UnscentedTransformPredictor']

--- a/src/prog_algs/predictors/toe_prediction_profile.py
+++ b/src/prog_algs/predictors/toe_prediction_profile.py
@@ -1,0 +1,28 @@
+# Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+from collections import UserDict
+
+from prog_algs.uncertain_data import UncertainData 
+
+class ToEPredictionProfile(UserDict):
+    """
+    """
+    def add_prediction(self, time_of_prediction: float, toe_prediction: UncertainData):
+        """Add a single prediction to the profile
+
+        Args:
+            time_of_prediction (float): Time that the prediction was made
+            toe_prediction (UncertainData): Distribution of predicted ToEs
+        """
+        self[time_of_prediction] = toe_prediction
+
+    def __iter__(self):
+        return iter(sorted(super(ToEPredictionProfile, self).__iter__()))
+
+    def items(self):
+        return iter((k, self[k]) for k in self)
+
+    def keys(self):
+        return sorted(super(ToEPredictionProfile, self).keys())
+
+    def values(self):
+        return [self[k] for k in self.keys()]

--- a/src/prog_algs/predictors/toe_prediction_profile.py
+++ b/src/prog_algs/predictors/toe_prediction_profile.py
@@ -5,6 +5,7 @@ from prog_algs.uncertain_data import UncertainData
 
 class ToEPredictionProfile(UserDict):
     """
+    Data structure for storing the result of multiple predictions, including time of prediction. This data structure can be treated as a dictionary of time of prediction to toe prediction. Iteration of this data structure is in order of increasing time of prediction
     """
     def add_prediction(self, time_of_prediction: float, toe_prediction: UncertainData):
         """Add a single prediction to the profile
@@ -15,6 +16,7 @@ class ToEPredictionProfile(UserDict):
         """
         self[time_of_prediction] = toe_prediction
 
+    # Functions below are defined to ensure that any iteration is in order of increasing time of prediction
     def __iter__(self):
         return iter(sorted(super(ToEPredictionProfile, self).__iter__()))
 

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -112,7 +112,6 @@ class TestPredictors(unittest.TestCase):
         # Test Metrics
         from prog_algs.metrics import samples
         s = toe.sample(100).key('EOD')
-        samples.toe_metrics(s)
         samples.eol_metrics(s)  # Kept for backwards compatibility
 
     def test_MC(self):
@@ -217,11 +216,19 @@ class TestPredictors(unittest.TestCase):
         self.assertEqual(len(profile), 4)
         for (t_p, t_p_real) in zip(profile.keys(), [0, 0.5, 0.75, 1]):
             self.assertAlmostEqual(t_p, t_p_real)
+        self.assertEqual(profile[0.75], ScalarData({'a': 1.075, 'b': 2.15, 'c': -3.125}))
 
         del profile[0.5]
         self.assertEqual(len(profile), 3)
         for (t_p, t_p_real) in zip(profile.keys(), [0, 0.75, 1]):
             self.assertAlmostEqual(t_p, t_p_real)
+        for ((t_p, toe), t_p_real) in zip(profile.items(), [0, 0.75, 1]):
+            self.assertAlmostEqual(t_p, t_p_real)
+        try:
+            tmp = profile[0.5]
+            # 0.5 doesn't exist anymore
+        except Exception:
+            pass
 
 # This allows the module to be executed directly    
 def run_tests():

--- a/tests/test_predictors.py
+++ b/tests/test_predictors.py
@@ -199,6 +199,29 @@ class TestPredictors(unittest.TestCase):
             self.fail()
         except Exception:
             pass
+    
+    def test_prediction_profile(self):
+        from prog_algs.predictors import ToEPredictionProfile
+        from prog_algs.uncertain_data import ScalarData
+        profile = ToEPredictionProfile()
+        self.assertEqual(len(profile), 0)
+
+        profile.add_prediction(0, ScalarData({'a': 1, 'b': 2, 'c': -3.2}))
+        profile.add_prediction(1, ScalarData({'a': 1.1, 'b': 2.2, 'c': -3.1}))
+        profile.add_prediction(0.5, ScalarData({'a': 1.05, 'b': 2.1, 'c': -3.15}))
+        self.assertEqual(len(profile), 3)
+        for (t_p, t_p_real) in zip(profile.keys(), [0, 0.5, 1]):
+            self.assertAlmostEqual(t_p, t_p_real)
+
+        profile[0.75] = ScalarData({'a': 1.075, 'b': 2.15, 'c': -3.125})
+        self.assertEqual(len(profile), 4)
+        for (t_p, t_p_real) in zip(profile.keys(), [0, 0.5, 0.75, 1]):
+            self.assertAlmostEqual(t_p, t_p_real)
+
+        del profile[0.5]
+        self.assertEqual(len(profile), 3)
+        for (t_p, t_p_real) in zip(profile.keys(), [0, 0.75, 1]):
+            self.assertAlmostEqual(t_p, t_p_real)
 
 # This allows the module to be executed directly    
 def run_tests():


### PR DESCRIPTION
Add new class for a ToE Prediction Profiles. These contain multiple predictions of Time of Event (ToE) including the time of prediction. To do this I leverage the built in class UserDict. The class acts like a dictionary, but is guaranteed to iterate in order of time of prediction (earliest prediction first). 

This class will be used with the ToE profile metrics (e.g., Alpha-Beta)

Requirements for data structure:
* Store time of prediction and ToE prediction 
* Ability to add new ToE predictions 
* Access will be in order of prediction time