### PR TITLE
Recorded final state in EOD distribution

### DIFF
--- a/examples/basic_example.py
+++ b/examples/basic_example.py
@@ -88,6 +88,10 @@ def run_example():
     # You can also access a state distribution at a specific time using the .snapshot function
     states_time_1 = states.snapshot(1)
     # now you have all the samples corresponding to times[1]
+
+    # You can also access the final state (of type UncertainData), like so:
+    final_state = toe.final_state
+    print('Final state @EOD: ', final_state['EOD'].mean)
     
     # You can also use the metrics package to generate some useful metrics on the result of a prediction
     print("\nEOD Prediction Metrics")

--- a/examples/utpredictor.py
+++ b/examples/utpredictor.py
@@ -2,7 +2,6 @@
 
 from prog_models.models import BatteryCircuit
 from prog_algs import *
-from prog_algs.uncertain_data import UnweightedSamples
 # from prog_algs.visualize import plot_hist
 # import matplotlib.pyplot as plt
 
@@ -51,7 +50,11 @@ def run_example():
         print('\tz = {}'.format(outputs.snapshot(i).mean))
         print('\tevent state = {}'.format(event_states.snapshot(i).mean))
 
-    print('\ToE:', toe)
+    print('\nToE:', toe.mean)
+
+    # You can also access the final state (of type UncertainData), like so:
+    final_state = toe.final_state
+    print('Final state @EOD: ', final_state['EOD'].mean)
     # toe.plot_hist()
     # plt.show()
 

--- a/src/prog_algs/predictors/unscented_transform.py
+++ b/src/prog_algs/predictors/unscented_transform.py
@@ -1,6 +1,5 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
-from typing import final
 from .prediction import MultivariateNormalDistPrediction, UnweightedSamplesPrediction
 from .predictor import Predictor
 from numpy import diag, array, transpose


### PR DESCRIPTION
We have a need to record the final state. With the refactoring of the output of prediction this was taken out of the state array. This PR adds it as a member of the ToE distribution in the format of {event_name: UncertainData} so toe.final_state['EOL'] gets the final state when event 'EOL' occurs. 