### PR TITLE
Fix bug in starting time

### DIFF
--- a/examples/playback.py
+++ b/examples/playback.py
@@ -97,15 +97,15 @@ def run_example():
             if (step%PREDICTION_UPDATE_FREQ == 0):
                 samples = filt.x.sample(NUM_SAMPLES)
                 (times, inputs, states, outputs, event_states, toe) = mc.predict(samples, future_loading, dt=TIME_STEP)
-                m = metrics.toe_metrics(toe)
-                print('  - ToE: {} (sigma: {})'.format(m['mean'], m['std']))
+                m = toe.metrics()
+                print('  - ToE: {} (sigma: {})'.format(m['EOD']['mean'], m['EOD']['std']))
 
                 # Update Plot
                 rul_x.append(t)
-                rul_y.append(m['mean']-t)
+                rul_y.append(m['EOD']['mean']-t)
                 ymin, ymax = rulax.get_ylim()
-                if m['mean']-t > ymax:
-                    rulax.set_ylim(0, (m['mean']-t)*1.1)
+                if m['EOD']['mean']-t > ymax:
+                    rulax.set_ylim(0, (m['EOD']['mean']-t)*1.1)
                 rul_line.set_data(rul_x, rul_y)
                 rul_fig.canvas.draw()
     

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -32,7 +32,7 @@ class ParticleFilter(state_estimator.StateEstimator):
             e.g., 0.5 or {'state1': 0.5, 'state2': 0.2}
     """
     default_parameters = {
-            't0': 0,
+            't0': -1,
             'num_particles': 20, 
             'resample_fcn': residual_resample,
             'x0_uncertainty': 0.5

--- a/src/prog_algs/state_estimators/unscented_kalman_filter.py
+++ b/src/prog_algs/state_estimators/unscented_kalman_filter.py
@@ -29,7 +29,7 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         'alpha': 1, 
         'beta': 0, 
         'kappa': -1,
-        't0': 0,
+        't0': -1,
         'dt': 1
     } 
 
@@ -94,6 +94,7 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
             Measured outputs, with keys defined by model.outputs.
             e.g., z = {'t':12.4, 'v':3.3} given inputs = ['t', 'v']
         """
+        assert t > self.t, "New time must be greater than previous"
         dt = t - self.t
         self.__input = u
         self.t = t


### PR DESCRIPTION
This should fix the issue in playback. 

The problem is when the first time is 0, time has not progressed (since default is 0) so time doesn't progress. 

Set to -1 as a start, not sure if this is the best way to fix it. 