### PR TITLE
Refactor MC

### DIFF
--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -3,62 +3,8 @@
 from .prediction import UnweightedSamplesPrediction
 from .predictor import Predictor
 from copy import deepcopy
-from functools import partial
 from prog_models.sim_result import SimResult, LazySimResult
 from prog_algs.uncertain_data import UnweightedSamples, UncertainData
-
-def prediction_fcn(x, model, params, events, loading):
-    # This is the main prediction function for the multi-threading
-    events_remaining = deepcopy(events)
-    first_output = model.output(x)
-    time_of_event = {}
-    last_state = {}
-    times = []
-    # inputs will be the same as states unless we explicitly deepcopy
-    inputs = SimResult()
-    states = SimResult()
-    outputs = LazySimResult(fcn = model.output)
-    event_states = LazySimResult(fcn = model.event_state)
-    params = deepcopy(params)
-    params['x'] = x
-    while len(events_remaining) > 0:  # Still events to predict
-        (t, u, xi, z, es) = model.simulate_to_threshold(loading, first_output, **params, threshold_keys=events_remaining, print=False)
-
-        # Add results
-        times.extend(t)
-        inputs.extend(u)
-        states.extend(xi)
-        outputs.extend(z)
-        event_states.extend(es)
-
-        # Get which event occurs
-        t_met = model.threshold_met(states[-1])
-        t_met = {key: t_met[key] for key in events_remaining}  # Only look at remaining keys
-        try:
-            event = list(t_met.keys())[list(t_met.values()).index(True)]
-        except ValueError:
-            # no event has occured
-            for event in events_remaining:
-                time_of_event[event] = None
-                last_state[event] = None
-            break
-
-        # An event has occured
-        time_of_event[event] = times[-1]
-        events_remaining.remove(event)  # No longer an event to predect to
-
-        # Remove last state (event)
-        params['t0'] = times.pop()
-        if 'horizon' in params:
-            # Reset horizon to account for time spent
-            params['horizon'] = params['horizon'] - params['t0']
-        inputs.pop()
-        params['x'] = states.pop()
-        last_state[event] = deepcopy(params['x'])
-        outputs.pop()
-        event_states.pop()
-        
-    return (times, inputs, states, outputs, event_states, time_of_event, last_state)
 
 
 class MonteCarlo(Predictor):
@@ -86,7 +32,10 @@ class MonteCarlo(Predictor):
     save_pts : List[float]
         Any additional savepoints (s) e.g., [10.1, 22.5]
     """
-    DEFAULT_N_SAMPLES = 100  # Default number of samples to use, if none specified
+
+    default_parameters = { 
+        'n_samples': 100  # Default number of samples to use, if none specified
+    }
 
     def predict(self, state : UncertainData, future_loading_eqn, **kwargs):
         if isinstance(state, dict):
@@ -98,23 +47,83 @@ class MonteCarlo(Predictor):
         params.update(kwargs) # update for specific run
 
         # Sample from state if n_samples specified or state is not UnweightedSamples
-        if 'n_samples' in params:
-            # If n_samples is specified, sample
-            state = state.sample(params['n_samples'])
-        elif not isinstance(state, UnweightedSamples):
-            # If no n_samples specified, but state is not UnweightedSamples, then sample with default
-            state = state.sample(self.DEFAULT_N_SAMPLES)
+        state = state.sample(params['n_samples'])
+
+        ouput_eqn = self.model.output
+        es_eqn = self.model.event_state
+        tm_eqn = self.model.threshold_met
+        simulate_to_threshold = self.model.simulate_to_threshold
+
+        time_of_event_all = []
+        last_states = []
+        times_all = []
+        inputs_all = []
+        states_all = []
+        outputs_all = []
+        event_states_all = []
 
         # Perform prediction
-        pred_fcn = partial(
-            prediction_fcn, 
-            model = self.model, 
-            params = params,
-            events = params['events'],
-            loading = future_loading_eqn)
-        
-        result = [pred_fcn(sample) for sample in state]
-        times_all, inputs_all, states_all, outputs_all, event_states_all, time_of_event, last_states = map(list, zip(*result))
+        for x in state:
+            events_remaining = deepcopy(params['events'])
+            first_output = ouput_eqn(x)
+            
+            time_of_event = {}
+            last_state = {}
+            times = []
+            inputs = SimResult()
+            states = SimResult()
+            outputs = LazySimResult(fcn = ouput_eqn)
+            event_states = LazySimResult(fcn = es_eqn)
+
+            params = deepcopy(params)
+            params['x'] = x
+
+            # Non-vectorized prediction
+            while len(events_remaining) > 0:  # Still events to predict
+                (t, u, xi, z, es) = simulate_to_threshold(future_loading_eqn, first_output, **params, threshold_keys=events_remaining, print=False)
+
+                # Add results
+                times.extend(t)
+                inputs.extend(u)
+                states.extend(xi)
+                outputs.extend(z)
+                event_states.extend(es)
+
+                # Get which event occurs
+                t_met = tm_eqn(states[-1])
+                t_met = {key: t_met[key] for key in events_remaining}  # Only look at remaining keys
+                try:
+                    event = list(t_met.keys())[list(t_met.values()).index(True)]
+                except ValueError:
+                    # no event has occured
+                    for event in events_remaining:
+                        time_of_event[event] = None
+                        last_state[event] = None
+                    break
+
+                # An event has occured
+                time_of_event[event] = times[-1]
+                events_remaining.remove(event)  # No longer an event to predect to
+
+                # Remove last state (event)
+                params['t0'] = times.pop()
+                if 'horizon' in params:
+                    # Reset horizon to account for time spent
+                    params['horizon'] = params['horizon'] - params['t0']
+                inputs.pop()
+                params['x'] = states.pop()
+                last_state[event] = deepcopy(params['x'])
+                outputs.pop()
+                event_states.pop()
+            
+            # Add to "all" structures
+            times_all.append(times)
+            inputs_all.append(inputs)
+            states_all.append(states)
+            outputs_all.append(outputs)
+            event_states_all.append(event_states)
+            time_of_event_all.append(time_of_event)
+            last_states.append(last_state)
         
         # Return longest time array
         times_length = [len(t) for t in times_all]
@@ -125,11 +134,12 @@ class MonteCarlo(Predictor):
         states_all = UnweightedSamplesPrediction(times, states_all)
         outputs_all = UnweightedSamplesPrediction(times, outputs_all)
         event_states_all = UnweightedSamplesPrediction(times, event_states_all)
-        time_of_event = UnweightedSamples(time_of_event)
+        time_of_event = UnweightedSamples(time_of_event_all)
 
         # Transform final states:
         last_states = {
             key: UnweightedSamples([sample[key] for sample in last_states]) for key in time_of_event.keys()
         }
         time_of_event.final_state = last_states
+
         return (times, inputs_all, states_all, outputs_all, event_states_all, time_of_event)

--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -107,9 +107,6 @@ class MonteCarlo(Predictor):
 
                 # Remove last state (event)
                 params['t0'] = times.pop()
-                if 'horizon' in params:
-                    # Reset horizon to account for time spent
-                    params['horizon'] = params['horizon'] - params['t0']
                 inputs.pop()
                 params['x'] = states.pop()
                 last_state[event] = deepcopy(params['x'])


### PR DESCRIPTION
MonteCarlo previously included a function for parallelization. The parallelization was dropped in a recent version due to some incompatibilities. These edits remove the function in favor of a for loop and added some caching for efficiency. 

In benchmarking on my computer this change reduces runtime by ~16%