### PR TITLE
Fix issue with first input being none for UTPredictor

### DIFF
--- a/src/prog_algs/predictors/unscented_transform.py
+++ b/src/prog_algs/predictors/unscented_transform.py
@@ -201,6 +201,7 @@ class UnscentedTransformPredictor(Predictor):
         state_keys = self.__state_keys
 
         # Simulation
+        self.__input = future_loading_eqn(t, state.mean)
         update_all()  # First State
         while t < params['horizon']:
             # Iterate through time


### PR DESCRIPTION
The First input wasn't actually calculated previously, making it none. 