### PR TITLE
Remove depreciated x0 initialization method 

### DIFF
--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -1,15 +1,16 @@
 # Copyright © 2021 United States Government as represented by the Administrator of the National Aeronautics and Space Administration.  All Rights Reserved.
 
-from prog_algs.uncertain_data.uncertain_data import UncertainData
-from typing import Callable
-from . import state_estimator
-from numpy import array, empty, random, take, exp, max, take
 from filterpy.monte_carlo import residual_resample
-from numbers import Number
+from numpy import array, empty, take, exp, max, take
 from scipy.stats import norm
-from ..uncertain_data import UnweightedSamples
-from ..exceptions import ProgAlgTypeError
+from typing import Callable
 from warnings import warn
+
+from prog_models.utils.containers import DictLikeMatrixWrapper
+
+from . import state_estimator
+from ..uncertain_data import UnweightedSamples, ScalarData, UncertainData
+from ..exceptions import ProgAlgTypeError
 
 
 class ParticleFilter(state_estimator.StateEstimator):
@@ -42,7 +43,6 @@ class ParticleFilter(state_estimator.StateEstimator):
             't0': -1e-99,  # practically 0, but allowing for a 0 first estimate
             'num_particles': 20, 
             'resample_fcn': residual_resample,
-            'x0_uncertainty': 0.5
         }
 
     def __init__(self, model, x0, measurement_eqn : Callable = None, **kwargs):
@@ -51,7 +51,6 @@ class ParticleFilter(state_estimator.StateEstimator):
         if measurement_eqn:
             warn("Warning: measurement_eqn depreciated as of v1.3.1, will be removed in v1.4. Use Model subclassing instead. See examples.measurement_eqn_example")
             # update output_container
-            from prog_models.utils.containers import DictLikeMatrixWrapper
             z0 = measurement_eqn(x0)
             class MeasureContainer(DictLikeMatrixWrapper):
                 def __init__(self, z):
@@ -64,24 +63,14 @@ class ParticleFilter(state_estimator.StateEstimator):
         else:
             self._measure = model.output
 
-        # Caching for optimization
-        paramters_x0_exist = 'x0_uncertainty' in self.parameters
-        if paramters_x0_exist: # Only create these optimizations if x0_uncertainty exists as key in self.parameters
-            parameters_x0_dict, parameters_x0_num = isinstance(self.parameters['x0_uncertainty'], dict), isinstance(self.parameters['x0_uncertainty'], Number)
         # Build array inplace
-        if isinstance(x0, UncertainData):
-            sample_gen = x0.sample(self.parameters['num_particles'])
-            samples = [array(sample_gen.key(k)) for k in x0.keys()]
-        elif paramters_x0_exist and (parameters_x0_dict or parameters_x0_num):
-            warn("Warning: x0_uncertainty depreciated as of v1.3, will be removed in v1.4. Use UncertainData type if estimating filtering with uncertain data.")
-            x = array(list(x0.values()))
-            if parameters_x0_dict:
-                sd = array([self.parameters['x0_uncertainty'][key] for key in x0.keys()])
-            elif parameters_x0_num:
-                sd = array([self.parameters['x0_uncertainty']] * len(x0))
-            samples = [random.normal(x[i], sd[i], self.parameters['num_particles']) for i in range(len(x))]
-        else:
-            raise ProgAlgTypeError("ProgAlgTypeError: x0 must be of type UncertainData or x0_uncertainty must be of type [dict, Number].")
+        if isinstance(x0, DictLikeMatrixWrapper) or isinstance(x0, dict):
+            x0 = ScalarData(x0)
+        elif not isinstance(x0, UncertainData):
+            raise ProgAlgTypeError(f"ProgAlgTypeError: x0 must be of type UncertainData or StateContainer, was {type(x0)}.")
+
+        sample_gen = x0.sample(self.parameters['num_particles'])
+        samples = [array(sample_gen.key(k)) for k in x0.keys()]
         
         self.particles = model.StateContainer(array(samples))
 

--- a/tests/test_state_estimators.py
+++ b/tests/test_state_estimators.py
@@ -234,7 +234,7 @@ class TestStateEstimators(unittest.TestCase):
         self.__incorrect_input_tests(UnscentedKalmanFilter)
 
     def test_PF(self):
-        m = ThrownObject(process_noise={'x': 0.25, 'v': 0.25}, measurement_noise=1)
+        m = ThrownObject(process_noise={'x': 0.75, 'v': 0.75}, measurement_noise=1)
         x_guess = {'x': 1.75, 'v': 38.5} # Guess of initial state, actual is {'x': 1.83, 'v': 40}
 
         filt = ParticleFilter(m, x_guess, num_particles = 1000)
@@ -282,12 +282,6 @@ class TestStateEstimators(unittest.TestCase):
         for k in mean1.keys():
             self.assertEqual(mean1[k], mean2[k])
         self.assertTrue((filt_scalar.x.cov == x_scalar.cov).all())
-        # Case 1: Only x0_uncertainty provided; expect a warning issued
-        with self.assertWarns(Warning):
-            filt_scalar = ParticleFilter(m, {'x': 1.75, 'v': 38.5}, x0_uncertainty = 0.5)
-        # Case 2: Raise ProgAlgTypeError if x0 not UncertainData or x0_uncertainty not of type {{dict, Number}}.
-        with self.assertRaises(ProgAlgTypeError):
-            filt_scalar = ParticleFilter(m, {'x': 1.75, 'v': 38.5}, num_particles = 20, x0_uncertainty = [])
         
     def test_PF_incorrect_input(self):
         self.__incorrect_input_tests(ParticleFilter)


### PR DESCRIPTION
This PR removed the x0_uncertainty key for initialization and adds support for dict or statecontainer initialization methods.

Removed associated tests as well (warning tests) and increased process noise  in test (needed because of the lack of default noise) and reordered imports. 