### PR TITLE
dt in Particle Filter

### DIFF
--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -71,6 +71,31 @@ class ParticleFilter(state_estimator.StateEstimator):
         return "{} State Estimator".format(self.__class__)
         
     def estimate(self, t : float, u, z, dt = None):
+        """
+        Perform one state estimation step (i.e., update the state estimate, filt.x)
+
+        Args
+        ----------
+        t : float
+            Current timestamp in seconds (≥ 0.0)
+            e.g., t = 3.4
+        u : InputContainer
+            Measured inputs, with keys defined by model.inputs.
+            e.g., u = m.InputContainer({'i':3.2}) given inputs = ['i']
+        z : OutputContainer
+            Measured outputs, with keys defined by model.outputs.
+            e.g., z = m.OutputContainer({'t':12.4, 'v':3.3}) given outputs = ['t', 'v']
+            
+        Keyword Args
+        ------------
+        dt : float, optional
+            Timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step
+            e.g., dt = 1e-2
+
+        Note
+        ----
+        This method updates the state estimate stored in filt.x, but doesn't return the updated estimate. Call filt.x to get the updated estimate.
+        """
         assert t > self.t, "New time must be greater than previous"
         if dt is None:
             dt = t - self.t

--- a/src/prog_algs/state_estimators/state_estimator.py
+++ b/src/prog_algs/state_estimators/state_estimator.py
@@ -56,7 +56,7 @@ class StateEstimator(ABC):
         """
         Perform one state estimation step (i.e., update the state estimate, filt.x)
 
-        Parameters
+        Args
         ----------
         t : float
             Current timestamp in seconds (≥ 0.0)

--- a/tests/test_state_estimators.py
+++ b/tests/test_state_estimators.py
@@ -258,9 +258,9 @@ class TestStateEstimators(unittest.TestCase):
 
         config = {
                 'dt': 0.01,
-                'save_freq': 0.5,
+                'save_freq': 1,
             }
-        simulated_results = m.simulate_to(3, future_loading, **config)
+        simulated_results = m.simulate_to(10, future_loading, **config)
 
         # Setup PF
         x0 = m.initialize(future_loading(0))
@@ -268,9 +268,9 @@ class TestStateEstimators(unittest.TestCase):
         t=0
         for u, z in zip(simulated_results.inputs, simulated_results.outputs):
             filt.estimate(t, u, z)
-            t += 0.5
+            t += config['save_freq']
 
-        # The stepsize (0.5) is way too large for this model. It grows unstable pretty quickly.
+        # The stepsize (1) is way too large for this model. It grows unstable pretty quickly.
         # The result is nans in the state
         self.assertTrue(np.isnan(filt.x.mean['k']))
 
@@ -278,8 +278,8 @@ class TestStateEstimators(unittest.TestCase):
         filt = ParticleFilter(m, x0, num_particles = 100)
         t=0
         for u, z in zip(simulated_results.inputs, simulated_results.outputs):
-            filt.estimate(t, u, z, dt = 0.001)
-            t += 0.5
+            filt.estimate(t, u, z, dt = 0.005)
+            t += config['save_freq']
         self.assertFalse(np.isnan(filt.x.mean['k']))
 
     def test_PF(self):


### PR DESCRIPTION
Added timestep (dt) feature for particle filter. Now when estimating the next state using a particle filter you can specify the timestep. The timestep will be used in the prediction step of the PF, predicting forward multiple times, recursively. This is important for models that become unstable at large timesteps. 