### PR TITLE
Hotfix/v1.4.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name = 'prog_algs',
-    version = '1.4.1',
+    version = '1.4.2',
     description = "The NASA Prognostics Algorithm Package is a framework for model-based prognostics (computation of remaining useful life) of engineering systems. It includes algorithms for state estimation and prediction, including uncertainty propagation. The algorithms use prognostic models (see prog_models) to perform estimation and prediction. The package enables rapid development of prognostics solutions for given models of components and systems. Algorithms can be swapped for comparative studies and evaluations",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/prog_algs/__init__.py
+++ b/src/prog_algs/__init__.py
@@ -5,7 +5,7 @@ from . import predictors, state_estimators, uncertain_data
 
 import warnings
 
-__version__ = '1.4.0'
+__version__ = '1.4.2'
 
 def run_prog_playback(obs, pred, future_loading, output_measurements, **kwargs):
     warnings.warn("Depreciated in 1.2.0, will be removed in a future release.", DeprecationWarning)

--- a/src/prog_algs/state_estimators/kalman_filter.py
+++ b/src/prog_algs/state_estimators/kalman_filter.py
@@ -115,8 +115,8 @@ class KalmanFilter(state_estimator.StateEstimator):
         assert t > self.t, "New time must be greater than previous"
 
         dt = t - self.t
-        # Create u array, ensuring order of model.inputs
-        inputs = np.array([u[key] for key in self.model.inputs])
+        # Create u array, ensuring order of model.inputs. And reshaping to (n,1), n can be 0.
+        inputs = np.array([u[key] for key in self.model.inputs]).reshape((-1,1))
 
         # Add row of ones (to account for constant E term)
         if np.size(inputs) == 0:


### PR DESCRIPTION
fixed issue with inputs dimensions at estimate stage in the kalman filter. Variable inputs is set by default to a shape (n,1), where n can be 0.