### PR TITLE
PF fixes and state limit extension

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -32,25 +32,25 @@ jobs:
         python -m pip install testbook
     - name: Run tests
       run: python -m tests
-  test-prog_models-released:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.7']
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install -e .
-        python -m pip install notebook
-        python -m pip install testbook
-    - name: Run tests
-      run: python -m tests
+  # test-prog_models-released:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       python-version: ['3.7']
+  #   steps:
+  #   - uses: actions/checkout@v2
+  #   - name: Set up Python ${{ matrix.python-version }}
+  #     uses: actions/setup-python@v2
+  #     with:
+  #       python-version: ${{ matrix.python-version }}
+  #   - name: Install
+  #     run: |
+  #       python -m pip install --upgrade pip
+  #       python -m pip install -e .
+  #       python -m pip install notebook
+  #       python -m pip install testbook
+  #   - name: Run tests
+  #     run: python -m tests
   copyright:
     runs-on: ubuntu-latest
     strategy:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'scipy',
         'filterpy',
         'matplotlib',
-        'prog_models>=1.4.0'
+        'prog_models>=1.5.0'
     ],
     license = 'NOSA',
     project_urls={  # Optional

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -110,6 +110,7 @@ class ParticleFilter(state_estimator.StateEstimator):
         particles = self.particles
         next_state = self.model.next_state
         apply_process_noise = self.model.apply_process_noise
+        apply_limits = self.model.apply_limits
         output = self._measure
         # apply_measurement_noise = self.model.apply_measurement_noise
         noise_params = self.model.parameters['measurement_noise']
@@ -123,6 +124,7 @@ class ParticleFilter(state_estimator.StateEstimator):
             while self.t < t:
                 dt_i = min(dt, t-self.t)
                 self.particles = apply_process_noise(next_state(particles, u, dt_i), dt_i)
+                self.particles = apply_limits(self.particles)
                 self.t += dt_i
 
             # Get particle measurements
@@ -135,6 +137,7 @@ class ParticleFilter(state_estimator.StateEstimator):
                     dt_i = min(dt, t-self.t)
                     x = next_state(x, u, dt_i) 
                     x = apply_process_noise(x, dt_i)
+                    x = apply_limits(x)
                     self.t += dt_i
                 for key in particles.keys():
                     self.particles[key][i] = x[key]


### PR DESCRIPTION
Extended Particle Filter to take advantage of state limit functionality in models. Also, fixed two issues:
* Only the first sample was simulated forward for non-vectorized models because of updating self.t. This was part of the new dt feature. 
* sometimes arrays were set to be integers, causing particles to round. 

This change relies on the vectorized state limit feature, introduced in the next release of prog_models, so I updated the dependencies accordingly, and commented out the prog_models v1.4 test