### PR TITLE
#218 Timestep in KF/UKF/PF

### DIFF
--- a/src/prog_algs/state_estimators/kalman_filter.py
+++ b/src/prog_algs/state_estimators/kalman_filter.py
@@ -30,7 +30,8 @@ class KalmanFilter(state_estimator.StateEstimator):
         alpha (float, optional):
             KF Scaling parameter. An alpha > 1 turns this into a fading memory filter.
         t0 (float, optional):
-            Starting time (s)
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
         dt (float, optional):
             time step (s)
         Q (list[list[float]], optional):
@@ -96,7 +97,7 @@ class KalmanFilter(state_estimator.StateEstimator):
         self.filter.F = F
         self.filter.B = B
 
-    def estimate(self, t: float, u, z):
+    def estimate(self, t: float, u, z, **kwargs):
         """
         Perform one state estimation step (i.e., update the state estimate)
 
@@ -111,10 +112,16 @@ class KalmanFilter(state_estimator.StateEstimator):
         z : dict
             Measured outputs, with keys defined by model.outputs.
             e.g., z = {'t':12.4, 'v':3.3} given inputs = ['t', 'v']
+
+        Keyword Arguments
+        -----------------
+        dt : float, optional
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
         """
         assert t > self.t, "New time must be greater than previous"
-
-        dt = t - self.t
+        dt = kwargs.get('dt', self.parameters['dt'])
+        dt = min(t - self.t, dt)  # Ensure dt is not larger than the maximum time step
         # Create u array, ensuring order of model.inputs. And reshaping to (n,1), n can be 0.
         inputs = np.array([u[key] for key in self.model.inputs]).reshape((-1,1))
 
@@ -123,8 +130,6 @@ class KalmanFilter(state_estimator.StateEstimator):
             inputs = np.array([[1]])
         else:
             inputs = np.append(inputs, [[1]], 0)
-
-        self.t = t
 
         # Update equations
         # prog_models is dx = Ax + Bu + E
@@ -135,7 +140,9 @@ class KalmanFilter(state_estimator.StateEstimator):
         F = np.multiply(self.filter.F, dt) + np.diag([1]* self.model.n_states)
 
         # Predict
-        self.filter.predict(u = inputs, B = B, F = F)
+        while self.t < t :
+            self.filter.predict(u = inputs, B = B, F = F)
+            self.t += dt
 
         # Create z array, ensuring order of model.outputs
         outputs = np.array([z[key] for key in self.model.outputs])

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -33,7 +33,8 @@ class ParticleFilter(state_estimator.StateEstimator):
         t0 (float, optional):
             Starting time (s)
         dt (float, optional): 
-            time step (s)
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
         num_particles (int, optional):
             Number of particles in particle filter
         resample_fcn (function, optional):
@@ -100,7 +101,7 @@ class ParticleFilter(state_estimator.StateEstimator):
         Keyword Args
         ------------
         dt : float, optional
-            Timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
             e.g., dt = 1e-2
 
         Note
@@ -109,7 +110,7 @@ class ParticleFilter(state_estimator.StateEstimator):
         """
         assert t > self.t, "New time must be greater than previous"
         if dt is None:
-            dt = t - self.t
+            dt = min(t - self.t, self.parameters['dt'])
 
         # Check Types
         if isinstance(u, dict):

--- a/src/prog_algs/state_estimators/state_estimator.py
+++ b/src/prog_algs/state_estimators/state_estimator.py
@@ -20,12 +20,20 @@ class StateEstimator(ABC):
         x0 (UncertainData, model.StateContainer, or dict):
             Initial (starting) state, with keys defined by model.states \n
             e.g., x = ScalarData({'abc': 332.1, 'def': 221.003}) given states = ['abc', 'def']
-    
-    See state-estimator specific documentation for speicfic keyword arguments.
+
+    Keywork Args:
+        t0 (float):
+            Initial time at which prediction begins, e.g., 0
+        dt (float):
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
+        **kwargs: 
+            See state-estimator specific documentation for speicfic keyword arguments.
     """
 
     default_parameters = {
-        't0': 0
+        't0': -1e-10,
+        'dt': float('inf')
     }
 
     def __init__(self, model, x0, **kwargs):
@@ -46,8 +54,21 @@ class StateEstimator(ABC):
                 raise ProgAlgTypeError("x0 missing state `{}`".format(key))
         
         # Process kwargs (configuration)
-        self.parameters = deepcopy(self.default_parameters)
+        self.parameters = deepcopy(StateEstimator.default_parameters)
+        self.parameters.update(self.default_parameters)
         self.parameters.update(kwargs)
+
+        if isinstance(self.parameters['t0'], int):
+            self.parameters['t0'] = float(self.parameters['t0'])
+        if isinstance(self.parameters['dt'], int):
+            self.parameters['dt'] = float(self.parameters['dt'])
+
+        if not isinstance(self.parameters['t0'], float):
+            raise ProgAlgTypeError(f"t0 must be float, was {type(self.parameters['t0'])}")
+        if not isinstance(self.parameters['dt'], float):
+            raise ProgAlgTypeError(f"dt must be float, was {type(self.parameters['dt'])}")
+        if self.parameters['dt'] <= 0:
+            raise ValueError(f"dt must be positive, was {self.parameters['dt']}")
 
         self.t = self.parameters['t0']  # Initial Time
 
@@ -67,6 +88,14 @@ class StateEstimator(ABC):
         z : OutputContainer
             Measured outputs, with keys defined by model.outputs.
             e.g., z = m.OutputContainer({'t':12.4, 'v':3.3}) given outputs = ['t', 'v']
+
+        Keyword Args
+        -------------
+            dt : float, optional
+                Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+                e.g., dt = 1e-2
+            **kwargs: 
+                See state-estimator specific documentation for speicfic keyword arguments.
 
         Note
         ----

--- a/src/prog_algs/state_estimators/unscented_kalman_filter.py
+++ b/src/prog_algs/state_estimators/unscented_kalman_filter.py
@@ -4,8 +4,8 @@ from filterpy import kalman
 from numpy import diag, array
 from warnings import warn
 
-from . import state_estimator
-from ..uncertain_data import MultivariateNormalDist, UncertainData
+from prog_algs.state_estimators import state_estimator
+from prog_algs.uncertain_data import MultivariateNormalDist, UncertainData
 
 class UnscentedKalmanFilter(state_estimator.StateEstimator):
     """
@@ -33,7 +33,8 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         t0 (float, optional):
             Starting time (s)
         dt (float, optional):
-            time step (s)
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
         Q (list[list[float]], optional):
             Process Noise Matrix 
         R (list[list[float]], optional):
@@ -43,8 +44,6 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         'alpha': 1, 
         'beta': 0, 
         'kappa': -1,
-        't0': -1e-10,
-        'dt': 1
     } 
 
     def __init__(self, model, x0, **kwargs):
@@ -63,7 +62,7 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
             return array(list(z.values())).ravel()
 
         if 'Q' not in self.parameters:
-            self.parameters['Q'] = diag([1.0e-3 for i in x0.keys()])
+            self.parameters['Q'] = diag([1.0e-3 for _ in x0.keys()])
 
         def state_transition(x, dt):
             x = model.StateContainer({key: value for (key, value) in zip(x0.keys(), x)})
@@ -95,7 +94,7 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         self.filter.Q = self.parameters['Q']
         self.filter.R = self.parameters['R']
 
-    def estimate(self, t: float, u, z):
+    def estimate(self, t: float, u, z, **kwargs):
         """
         Perform one state estimation step (i.e., update the state estimate)
 
@@ -110,12 +109,20 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         z : dict
             Measured outputs, with keys defined by model.outputs.
             e.g., z = {'t':12.4, 'v':3.3} given inputs = ['t', 'v']
+
+        Keyword Args
+        ------------
+        dt : float, optional
+            Maximum timestep for prediction in seconds. By default is the difference between new and last t. Some models are unstable at larger dt. Setting a smaller dt will force the model to take smaller steps; resulting in multiple prediction steps for each estimate step. Default is the parameters['dt]
+            e.g., dt = 1e-2
         """
         assert t > self.t, "New time must be greater than previous"
-        dt = t - self.t
+        dt = kwargs.get('dt', self.parameters['dt'])
+        dt = min(t - self.t, dt)
         self.__input = u
-        self.t = t
-        self.filter.predict(dt=dt)
+        while self.t < t:
+            self.filter.predict(dt=dt)
+            self.t += dt
         self.filter.update(array(list(z.values())))
     
     @property
@@ -127,4 +134,4 @@ class UnscentedKalmanFilter(state_estimator.StateEstimator):
         -------
         state = observer.x
         """
-        return MultivariateNormalDist(self.x0.keys(), self.filter.x, self.filter.P, _type = self.model.StateContainer)
+        return MultivariateNormalDist(self.x0.keys(), self.filter.x, self.filter.P, _type=self.model.StateContainer)

--- a/tests/test_state_estimators.py
+++ b/tests/test_state_estimators.py
@@ -83,22 +83,29 @@ class TestStateEstimators(unittest.TestCase):
         se = TemplateStateEstimator(self._m_mock, {'a': 0.0, 'b': 0.0, 'c': 0.0, 't':0.0})
 
     def __test_state_est(self, filt, m):
-        x_guess = m.StateContainer(filt.x.mean)  # Might be new
         x = m.initialize()
 
         self.assertTrue(all(key in filt.x.mean for key in m.states))
 
         # run for a while
-        dt = 0.01
+        dt = 0.2
         u = m.InputContainer({})
-        for i in range(1250):
+        last_time = 0
+        for i in range(500):
             # Get simulated output (would be measured in a real application)
             x = m.next_state(x, u, dt)
-            x_guess = m.next_state(x_guess, u, dt)
             z = m.output(x)
 
-            # Estimate New State
-            filt.estimate((i+1)*dt, u, z)
+            # Estimate New State every few steps
+            if i % 8 == 0:
+                # This is to test dt
+                # Without dt, this would fail
+                last_time = (i+1)*dt
+                filt.estimate((i+1)*dt, u, z, dt=dt)
+
+        if last_time != (i+1)*dt:
+            # Final estimate
+            filt.estimate((i+1)*dt, u, z, dt=dt)
 
         # Check results - make sure it converged
         x_est = filt.x.mean


### PR DESCRIPTION
Add the ability to set the maximum timestep for state estimation. This is important for models like BatteryElectroChem that become unstable with large timesteps. the result will be that multiple prediction steps will be taken for every estimation step if the difference between provided data is greater than the maximum timestep. 