### PR TITLE
Hotfix v1.5.1

### DIFF
--- a/examples/horizon.py
+++ b/examples/horizon.py
@@ -20,7 +20,7 @@ def run_example():
     # Step 1: Setup model & future loading
     def future_loading(t, x = None):
         return {}
-    m = ThrownObject(process_noise = 0.25, measurement_noise = 0.2)
+    m = ThrownObject(process_noise = 0.12, measurement_noise = 0.1)# ThrownObject(process_noise = 0.25, measurement_noise = 0.2)
     initial_state = m.initialize()
 
     # Step 2: Demonstrating state estimator
@@ -50,9 +50,9 @@ def run_example():
     # THIS IS WHERE WE DIVERGE FROM THE THROWN_OBJECT_EXAMPLE
     # Here we set a prediction horizon
     # We're saying we are not interested in any events that occur after this time
-    PREDICTION_HORIZON = 7.75
+    PREDICTION_HORIZON = 7.672
     samples = filt.x  # Since we're using a particle filter, which is also sample-based, we can directly use the samples, without changes
-    STEP_SIZE = 0.01
+    STEP_SIZE = 0.001 #0.01
     mc_results = mc.predict(samples, future_loading, dt=STEP_SIZE, horizon = PREDICTION_HORIZON)
     print("\nPredicted Time of Event:")
     metrics = mc_results.time_of_event.metrics()
@@ -65,6 +65,8 @@ def run_example():
     # Step 4: Show all plots
     import matplotlib.pyplot as plt  # For plotting
     plt.show()
+
+    debug = 1
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/examples/horizon.py
+++ b/examples/horizon.py
@@ -20,7 +20,7 @@ def run_example():
     # Step 1: Setup model & future loading
     def future_loading(t, x = None):
         return {}
-    m = ThrownObject(process_noise = 0.12, measurement_noise = 0.1)# ThrownObject(process_noise = 0.25, measurement_noise = 0.2)
+    m = ThrownObject(process_noise = 0.2, measurement_noise = 0.1)
     initial_state = m.initialize()
 
     # Step 2: Demonstrating state estimator
@@ -50,9 +50,9 @@ def run_example():
     # THIS IS WHERE WE DIVERGE FROM THE THROWN_OBJECT_EXAMPLE
     # Here we set a prediction horizon
     # We're saying we are not interested in any events that occur after this time
-    PREDICTION_HORIZON = 7.672
+    PREDICTION_HORIZON = 7.67
     samples = filt.x  # Since we're using a particle filter, which is also sample-based, we can directly use the samples, without changes
-    STEP_SIZE = 0.001 #0.01
+    STEP_SIZE = 0.001
     mc_results = mc.predict(samples, future_loading, dt=STEP_SIZE, horizon = PREDICTION_HORIZON)
     print("\nPredicted Time of Event:")
     metrics = mc_results.time_of_event.metrics()
@@ -60,13 +60,11 @@ def run_example():
     mc_results.time_of_event.plot_hist(keys = 'impact')
     mc_results.time_of_event.plot_hist(keys = 'falling')
 
-    print("\nSamples where impact occurs before horizon: {:.2f}%".format(metrics['impact']['number of samples']/NUM_SAMPLES*100))
+    print("\nSamples where impact occurs before horizon: {:.2f}%".format(metrics['impact']['number of samples']/mc.parameters['n_samples']*100))
     
     # Step 4: Show all plots
     import matplotlib.pyplot as plt  # For plotting
     plt.show()
-
-    debug = 1
 
 # This allows the module to be executed directly 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ long_description = (here / 'README.md').read_text(encoding='utf-8')
 
 setup(
     name = 'prog_algs',
-    version = '1.5.0',
+    version = '1.5.1',
     description = "The NASA Prognostics Algorithm Package is a framework for model-based prognostics (computation of remaining useful life) of engineering systems. It includes algorithms for state estimation and prediction, including uncertainty propagation. The algorithms use prognostic models (see prog_models) to perform estimation and prediction. The package enables rapid development of prognostics solutions for given models of components and systems. Algorithms can be swapped for comparative studies and evaluations",
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/src/prog_algs/__init__.py
+++ b/src/prog_algs/__init__.py
@@ -5,7 +5,7 @@ from . import predictors, state_estimators, uncertain_data
 
 import warnings
 
-__version__ = '1.5.0'
+__version__ = '1.5.1'
 
 def run_prog_playback(obs, pred, future_loading, output_measurements, **kwargs):
     warnings.warn("Depreciated in 1.2.0, will be removed in a future release.", DeprecationWarning)

--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -95,10 +95,6 @@ class MonteCarlo(Predictor):
                     **params
                 )
             else:
-                # Since horizon is relative to t0 (the simulation starting point),
-                # we must subtract the difference in current t0 from the initial (i.e., prediction t0)
-                # each subsequent simulation
-                # params['horizon'] = HORIZON - (params['t0'] - t0)
 
                 # Simulate
                 events_remaining = params['events'].copy()
@@ -111,6 +107,9 @@ class MonteCarlo(Predictor):
 
                 # Non-vectorized prediction
                 while len(events_remaining) > 0:  # Still events to predict
+                    # Since horizon is relative to t0 (the simulation starting point),
+                    # we must subtract the difference in current t0 from the initial (i.e., prediction t0)
+                    # each subsequent simulation
                     params['horizon'] = HORIZON - (params['t0'] - t0)
                     (t, u, xi, z, es) = simulate_to_threshold(future_loading_eqn,       
                         first_output, 

--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -98,7 +98,7 @@ class MonteCarlo(Predictor):
                 # Since horizon is relative to t0 (the simulation starting point),
                 # we must subtract the difference in current t0 from the initial (i.e., prediction t0)
                 # each subsequent simulation
-                params['horizon'] = HORIZON - (params['t0'] - t0)
+                # params['horizon'] = HORIZON - (params['t0'] - t0)
 
                 # Simulate
                 events_remaining = params['events'].copy()
@@ -111,6 +111,7 @@ class MonteCarlo(Predictor):
 
                 # Non-vectorized prediction
                 while len(events_remaining) > 0:  # Still events to predict
+                    params['horizon'] = HORIZON - (params['t0'] - t0)
                     (t, u, xi, z, es) = simulate_to_threshold(future_loading_eqn,       
                         first_output, 
                         threshold_keys = events_remaining,

--- a/src/prog_algs/predictors/monte_carlo.py
+++ b/src/prog_algs/predictors/monte_carlo.py
@@ -74,6 +74,7 @@ class MonteCarlo(Predictor):
 
         # Perform prediction
         t0 = params.get('t0', 0)
+        HORIZON = params.get('horizon', float('inf'))  # Save the horizon to be used later
         for x in state:
             first_output = self.model.output(x)
             
@@ -82,6 +83,7 @@ class MonteCarlo(Predictor):
 
             params['t0'] = t0
             params['x'] = x
+            params['horizon'] = HORIZON  # reset to initial horizon
 
             if 'save_freq' in params and not isinstance(params['save_freq'], tuple):
                 params['save_freq'] = (params['t0'], params['save_freq'])
@@ -93,6 +95,12 @@ class MonteCarlo(Predictor):
                     **params
                 )
             else:
+                # Since horizon is relative to t0 (the simulation starting point),
+                # we must subtract the difference in current t0 from the initial (i.e., prediction t0)
+                # each subsequent simulation
+                params['horizon'] = HORIZON - (params['t0'] - t0)
+
+                # Simulate
                 events_remaining = params['events'].copy()
 
                 times = []

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -81,7 +81,7 @@ class ParticleFilter(state_estimator.StateEstimator):
     def __str__(self):
         return "{} State Estimator".format(self.__class__)
         
-    def estimate(self, t : float, u, z, dt = None):
+    def estimate(self, t: float, u, z, dt = None):
         """
         Perform one state estimation step (i.e., update the state estimate, filt.x)
 

--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -67,9 +67,9 @@ class ParticleFilter(state_estimator.StateEstimator):
                 # Added to avoid float/int issues
                 self.parameters['num_particles'] = int(self.parameters['num_particles'])
             sample_gen = x0.sample(self.parameters['num_particles'])
-        samples = [array(sample_gen.key(k), dtype=float64) for k in x0.keys()]
+        samples = {k: array(sample_gen.key(k), dtype=float64) for k in x0.keys()}
         
-        self.particles = model.StateContainer(array(samples, dtype=float64))
+        self.particles = model.StateContainer(samples)
 
         if 'R' in self.parameters:
             # For backwards compatibility

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -7,6 +7,7 @@ from .test_examples import main as examples_main
 from .test_metrics import run_tests as metrics_main
 from .test_visualize import run_tests as visualize_main
 from .test_tutorials import run_tests as tutorials_main
+from .test_horizon import run_tests as horizon_main
 
 import unittest
 import sys
@@ -66,6 +67,11 @@ if __name__ == '__main__':
 
     try:
         tutorials_main()
+    except Exception:
+        was_successful = False
+
+    try:
+        horizon_main_main()
     except Exception:
         was_successful = False
 

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -1,11 +1,9 @@
 from io import StringIO
 import sys
 import unittest
-import numpy as np
 
 from prog_models.models.thrown_object import ThrownObject
 from prog_algs import *
-from pprint import pprint
 
 class TestHorizon(unittest.TestCase):
     def setUp(self):
@@ -63,7 +61,7 @@ class TestHorizon(unittest.TestCase):
 # This allows the module to be executed directly
 def run_tests():
     unittest.main()
-    
+
 def main():
     load_test = unittest.TestLoader()
     runner = unittest.TextTestRunner()

--- a/tests/test_horizon.py
+++ b/tests/test_horizon.py
@@ -1,0 +1,77 @@
+from io import StringIO
+import sys
+import unittest
+import numpy as np
+
+from prog_models.models.thrown_object import ThrownObject
+from prog_algs import *
+from pprint import pprint
+
+class TestHorizon(unittest.TestCase):
+    def setUp(self):
+        # set stdout (so it won't print)
+        sys.stdout = StringIO()
+
+    def tearDown(self):
+        sys.stdout = sys.__stdout__
+    
+    def test_horizon_ex(self):
+        # Setup model 
+        m = ThrownObject(process_noise = 0.25, measurement_noise = 0.2) 
+        # Change parameters (to make simulation faster) 
+        m.parameters['thrower_height'] = 1.0
+        m.parameters['throwing_speed'] = 10.0
+        initial_state = m.initialize()
+
+        # Define future loading (necessary for prediction call) 
+        def future_loading(t, x = None):
+            return {}
+
+        # Setup Predictor (smaller sample size for efficiency)
+        mc = predictors.MonteCarlo(m)
+        mc.parameters['n_samples'] = 50
+
+        # Perform a prediction
+        # With this horizon, all samples will reach 'falling', but only some will reach 'impact'
+        PREDICTION_HORIZON = 2.127 
+        STEP_SIZE = 0.001 
+        mc_results = mc.predict(initial_state, future_loading, dt=STEP_SIZE, horizon = PREDICTION_HORIZON)
+
+        # 'falling' happens before the horizon is met
+        falling_res = [mc_results.time_of_event[iter]['falling'] for iter in range(mc.parameters['n_samples']) if mc_results.time_of_event[iter]['falling'] is not None]
+        self.assertEqual(len(falling_res), mc.parameters['n_samples'])
+
+        # 'impact' happens around the horizon, so some samples have reached this event and others haven't
+        impact_res = [mc_results.time_of_event[iter]['impact'] for iter in range(mc.parameters['n_samples']) if mc_results.time_of_event[iter]['impact'] is not None]
+        self.assertLess(len(impact_res), mc.parameters['n_samples'])
+
+        # Try again with very low prediction_horizon, where no events are reached
+        # Note: here we count how many None values there are for each event (in the above and below examples, we count values that are NOT None)
+        mc_results_no_event = mc.predict(initial_state, future_loading, dt=STEP_SIZE, horizon = 0.3)
+        falling_res_no_event = [mc_results_no_event.time_of_event[iter]['falling'] for iter in range(mc.parameters['n_samples']) if mc_results_no_event.time_of_event[iter]['falling'] is None]
+        impact_res_no_event = [mc_results_no_event.time_of_event[iter]['impact'] for iter in range(mc.parameters['n_samples']) if mc_results_no_event.time_of_event[iter]['impact'] is None]
+        self.assertEqual(len(falling_res_no_event), mc.parameters['n_samples'])
+        self.assertEqual(len(impact_res_no_event), mc.parameters['n_samples'])
+
+        # Finally, try without horizon, all events should be reached for all samples
+        mc_results_all_event = mc.predict(initial_state, future_loading, dt=STEP_SIZE)
+        falling_res_all_event = [mc_results_all_event.time_of_event[iter]['falling'] for iter in range(mc.parameters['n_samples']) if mc_results_all_event.time_of_event[iter]['falling'] is not None]
+        impact_res_all_event = [mc_results_all_event.time_of_event[iter]['impact'] for iter in range(mc.parameters['n_samples']) if mc_results_all_event.time_of_event[iter]['impact'] is not None]
+        self.assertEqual(len(falling_res_all_event), mc.parameters['n_samples'])
+        self.assertEqual(len(impact_res_all_event), mc.parameters['n_samples'])
+
+# This allows the module to be executed directly
+def run_tests():
+    unittest.main()
+    
+def main():
+    load_test = unittest.TestLoader()
+    runner = unittest.TextTestRunner()
+    print("\n\nTesting Horizon functionality")
+    result = runner.run(load_test.loadTestsFromTestCase(TestHorizon)).wasSuccessful()
+
+    if not result:
+        raise Exception("Failed test")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes an issue with horizon. 

When 1. a user sets a horizon, 2. one event occurs before the horizon, and 3. the horizon is hit before the second event - then horizon will not work properly

Root cause is a change in prog_models where horizon is now relative to t0. t0 is used to simulate subsequent events (continuing from where the last one stopped).

Solution is to reduce horizon by t0 when continuing simulation