### PR TITLE
fixing bug: array and keys did not match in particle_filter

### DIFF
--- a/src/prog_algs/state_estimators/particle_filter.py
+++ b/src/prog_algs/state_estimators/particle_filter.py
@@ -67,9 +67,9 @@ class ParticleFilter(state_estimator.StateEstimator):
                 # Added to avoid float/int issues
                 self.parameters['num_particles'] = int(self.parameters['num_particles'])
             sample_gen = x0.sample(self.parameters['num_particles'])
-        samples = [array(sample_gen.key(k), dtype=float64) for k in x0.keys()]
+        samples = {k: array(sample_gen.key(k), dtype=float64) for k in x0.keys()}
         
-        self.particles = model.StateContainer(array(samples, dtype=float64))
+        self.particles = model.StateContainer(samples)
 
         if 'R' in self.parameters:
             # For backwards compatibility


### PR DESCRIPTION
Changes from https://github.com/nasa/progpy/pull/77

bug found and solution written by @mstraut

Solves issues where array values and keys do not match when 1. Do not call m.initialize(), and instead 2. provide a state as a dictionary instead of a state container, and 3. order the states in a different order than m.states